### PR TITLE
Add news aggregator agent with tests

### DIFF
--- a/ai_engine/__init__.py
+++ b/ai_engine/__init__.py
@@ -1,3 +1,3 @@
-from .agents import summarizer
+from .agents import summarizer, NewsAggregatorAgent
 
-__all__ = ["summarizer"]
+__all__ = ["summarizer", "NewsAggregatorAgent"]

--- a/ai_engine/agents/__init__.py
+++ b/ai_engine/agents/__init__.py
@@ -1,3 +1,4 @@
 from .summarizer import summarize
+from .news_aggregator_agent import NewsAggregatorAgent
 
-__all__ = ["summarize"]
+__all__ = ["summarize", "NewsAggregatorAgent"]

--- a/ai_engine/agents/news_aggregator_agent.py
+++ b/ai_engine/agents/news_aggregator_agent.py
@@ -1,0 +1,47 @@
+import json
+import logging
+from typing import Dict, List
+
+from ..common.gpt_utils import send_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class NewsAggregatorAgent:
+    """Agent that generates a daily news digest using ChatGPT."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo") -> None:
+        self.model = model
+
+    def generate_daily_digest(self) -> Dict[str, List[str]]:
+        """Generate and return today's news digest as a structured dict."""
+        system_prompt = (
+            "You are a helpful news aggregation assistant. "
+            "Provide concise bullet summaries for each requested category."
+        )
+        user_prompt = (
+            "Generate today's top news summaries across:\n"
+            "- Global Headlines\n"
+            "- Finance & Economy\n"
+            "- Politics (US, UK, India)\n"
+            "- Sports\n"
+            "- Science & Tech\n"
+            "Respond only with JSON in the specified format."
+        )
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+
+        logger.info("Requesting news digest from OpenAI")
+        response_text = send_prompt(messages, model=self.model)
+
+        try:
+            digest = json.loads(response_text)
+        except json.JSONDecodeError as exc:
+            logger.error("Failed to parse JSON response: %s", exc)
+            raise ValueError("Invalid JSON from OpenAI") from exc
+
+        return digest
+

--- a/ai_engine/common/gpt_utils.py
+++ b/ai_engine/common/gpt_utils.py
@@ -1,0 +1,33 @@
+import logging
+import time
+from typing import List, Dict
+
+import openai
+
+logger = logging.getLogger(__name__)
+
+
+def send_prompt(
+    messages: List[Dict[str, str]],
+    model: str = "gpt-3.5-turbo",
+    max_tokens: int = 500,
+    temperature: float = 0.0,
+    max_retries: int = 3,
+) -> str:
+    """Send a chat completion request to OpenAI with retries."""
+    for attempt in range(max_retries):
+        try:
+            response = openai.ChatCompletion.create(
+                model=model,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+            logger.info("OpenAI API call successful")
+            return response["choices"][0]["message"]["content"]
+        except Exception as exc:  # broad except for simplicity
+            logger.error("OpenAI API error: %s", exc)
+            if attempt >= max_retries - 1:
+                raise
+            time.sleep(2 ** attempt)
+

--- a/tests/ai_engine/test_news_aggregator_agent.py
+++ b/tests/ai_engine/test_news_aggregator_agent.py
@@ -1,0 +1,31 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from ai_engine.agents.news_aggregator_agent import NewsAggregatorAgent
+
+
+def test_generate_daily_digest(monkeypatch):
+    expected = {
+        "Global Headlines": ["gh"],
+        "Finance & Economy": ["fe"],
+        "Politics": {"US": ["us"], "UK": ["uk"], "India": ["in"]},
+        "Sports": ["sp"],
+        "Science & Tech": ["st"],
+    }
+
+    def mock_send_prompt(messages, **kwargs):
+        mock_send_prompt.last_messages = messages
+        return json.dumps(expected)
+
+    monkeypatch.setattr("ai_engine.agents.news_aggregator_agent.send_prompt", mock_send_prompt)
+
+    agent = NewsAggregatorAgent()
+    result = agent.generate_daily_digest()
+
+    assert result == expected
+    assert mock_send_prompt.last_messages[0]["role"] == "system"
+    assert "Politics" in expected
+


### PR DESCRIPTION
## Summary
- add reusable `send_prompt` helper for OpenAI requests
- implement `NewsAggregatorAgent` to create a daily news digest
- expose `NewsAggregatorAgent` via ai_engine package
- test news aggregation workflow with a mocked GPT response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d678d5bc83279f8363b2e86929a0